### PR TITLE
Adopt @JsFunction on several interfaces.

### DIFF
--- a/core/src/main/java/arez/Function.java
+++ b/core/src/main/java/arez/Function.java
@@ -1,11 +1,14 @@
 package arez;
 
+import jsinterop.annotations.JsFunction;
+
 /**
  * Functional interface for returning a value.
  *
  * @param <T> The type of the returned value.
  */
 @FunctionalInterface
+@JsFunction
 public interface Function<T>
 {
   /**

--- a/core/src/main/java/arez/Procedure.java
+++ b/core/src/main/java/arez/Procedure.java
@@ -1,9 +1,12 @@
 package arez;
 
+import jsinterop.annotations.JsFunction;
+
 /**
  * Interface for performing an action that does not return a value.
  */
 @FunctionalInterface
+@JsFunction
 public interface Procedure
 {
   /**

--- a/core/src/main/java/arez/Reaction.java
+++ b/core/src/main/java/arez/Reaction.java
@@ -1,12 +1,14 @@
 package arez;
 
 import javax.annotation.Nonnull;
+import jsinterop.annotations.JsFunction;
 
 /**
  * Interface that accepts an {@link Observer} that has been scheduled and
  * performs the actions required to run observer.
  */
 @FunctionalInterface
+@JsFunction
 interface Reaction
 {
   /**
@@ -15,6 +17,6 @@ interface Reaction
    * @param observer the observer of changes.
    * @throws Throwable if there is an error reacting to changes.
    */
-  void react( @Nonnull Observer observer )
+  void react( @SuppressWarnings( "unusable-by-js" ) @Nonnull Observer observer )
     throws Throwable;
 }

--- a/core/src/main/java/arez/ReactionEnvironment.java
+++ b/core/src/main/java/arez/ReactionEnvironment.java
@@ -1,12 +1,14 @@
 package arez;
 
 import javax.annotation.Nonnull;
+import jsinterop.annotations.JsFunction;
 
 /**
  * Interface that used to setup environment in which to run reactions.
  * Typically this is used to flag other systems to enable change batching etc.
  */
 @FunctionalInterface
+@JsFunction
 public interface ReactionEnvironment
 {
   /**

--- a/core/src/main/java/arez/RunProcedureAsActionReaction.java
+++ b/core/src/main/java/arez/RunProcedureAsActionReaction.java
@@ -19,7 +19,7 @@ final class RunProcedureAsActionReaction
    * {@inheritDoc}
    */
   @Override
-  public void react( @Nonnull final Observer observer )
+  public void react( @SuppressWarnings("unusable-by-js")  @Nonnull final Observer observer )
     throws Throwable
   {
     final Procedure action;

--- a/core/src/main/java/arez/RunProcedureReaction.java
+++ b/core/src/main/java/arez/RunProcedureReaction.java
@@ -17,7 +17,7 @@ final class RunProcedureReaction
    * {@inheritDoc}
    */
   @Override
-  public void react( @Nonnull final Observer observer )
+  public void react( @SuppressWarnings( "unusable-by-js" ) @Nonnull final Observer observer )
     throws Throwable
   {
     _action.call();

--- a/core/src/main/java/arez/SafeFunction.java
+++ b/core/src/main/java/arez/SafeFunction.java
@@ -1,11 +1,14 @@
 package arez;
 
+import jsinterop.annotations.JsFunction;
+
 /**
  * Functional interface for returning a value.
  *
  * @param <T> The type of the returned value.
  */
 @FunctionalInterface
+@JsFunction
 public interface SafeFunction<T>
 {
   /**

--- a/core/src/main/java/arez/SafeProcedure.java
+++ b/core/src/main/java/arez/SafeProcedure.java
@@ -1,9 +1,12 @@
 package arez;
 
+import jsinterop.annotations.JsFunction;
+
 /**
  * Interface for performing an action that does not return a value.
  */
 @FunctionalInterface
+@JsFunction
 public interface SafeProcedure
 {
   /**


### PR DESCRIPTION
This actually increases code-size in GWT 2.8.2 (due to extra class literals?)
but decreases code-size in J2CL. Due to code-size increase it has not been
applied to master